### PR TITLE
Supporting LDAPS and using SearchBindDN user to perform the search

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,7 +21,9 @@ kubernetes-ldap --ldap-host ldap.example.com \
     --ldap-base-dn "DC=example,DC=com" \
     --tls-cert-file pathToCert \
     --tls-private-key-file pathToKey \
-    --ldap-user-attribute userPrincipalName
+    --ldap-user-attribute userPrincipalName \
+    --ldap-search-user-dn "OU=engineering,DC=example,DC=com" (optional) \
+    --ldap-search-user-password pwd (optional)
 ```
 
 Configuring the Kubernetes Webhook

--- a/cmd/kubernetes-ldap.go
+++ b/cmd/kubernetes-ldap.go
@@ -27,6 +27,7 @@ var flBaseDN = flag.String("ldap-base-dn", "", "LDAP user base DN in the form 'd
 var flUserLoginAttribute = flag.String("ldap-user-attribute", "uid", "LDAP Username attribute for login")
 var flSearchUserDN = flag.String("ldap-search-user-dn", "", "Search user DN for this app to find users (e.g.: cn=admin,dc=example,dc=com).")
 var flSearchUserPassword = flag.String("ldap-search-user-password", "", "Search user password")
+var flSkipLdapTLSVerification = flag.Bool("ldap-skip-tls-verification", false, "Skip LDAP server TLS verification")
 
 var flServerPort = flag.Uint("port", 4000, "Local port this proxy server will run on")
 var flTLSCertFile = flag.String("tls-cert-file", "",
@@ -68,8 +69,10 @@ func main() {
 		glog.Errorf("Error creating token verifier: %v", err)
 	}
 
-	// TODO(abrand): Figure out LDAP TLS config
-	var ldapTLSConfig *tls.Config
+	ldapTLSConfig := &tls.Config{
+		ServerName:         *flLdapHost,
+		InsecureSkipVerify: *flSkipLdapTLSVerification,
+	}
 
 	ldapClient := &ldap.Client{
 		BaseDN:             *flBaseDN,
@@ -77,6 +80,8 @@ func main() {
 		LdapPort:           *flLdapPort,
 		AllowInsecure:      *flLdapAllowInsecure,
 		UserLoginAttribute: *flUserLoginAttribute,
+		SearchUserDN:       *flSearchUserDN,
+		SearchUserPassword: *flSearchUserPassword,
 		TLSConfig:          ldapTLSConfig,
 	}
 


### PR DESCRIPTION
- Using a basic TLSConfig to support LDAPS where you can specify ldap-skip-tls-verification just in case the DNS does not match the TLS cert one.

- Supporting a search bind DN user to perform the search, given that in most setups regular users don't perform search normally. If this search bind DN user doesn't exist the user to authenticate will be used.
Also, the search ensures the user exists within the BaseDN scope.